### PR TITLE
Add Support for x-ms-faultinjector-response-option

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Primitives;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -18,268 +17,273 @@ using System.Threading.Tasks;
 
 namespace HttpFaultInjector
 {
-    public static class Program
-    {
-        private static readonly HttpClient _httpClient = new HttpClient();
+	public static class Program
+	{
+		private static readonly HttpClient _httpClient = new HttpClient();
 
-        private static IList<KeyValuePair<string, string>> _selectionDescriptions = new List<KeyValuePair<string, string>>()
-        {
-            new KeyValuePair<string, string>("f", "Full response"),
-            new KeyValuePair<string, string>("p", "Partial Response (full headers, 50% of body), then wait indefinitely"),
-            new KeyValuePair<string, string>("pc", "Partial Response (full headers, 50% of body), then close (TCP FIN)"),
-            new KeyValuePair<string, string>("pa", "Partial Response (full headers, 50% of body), then abort (TCP RST)"),
-            new KeyValuePair<string, string>("n", "No response, then wait indefinitely"),
-            new KeyValuePair<string, string>("nc", "No response, then close (TCP FIN)"),
-            new KeyValuePair<string, string>("na", "No response, then abort (TCP RST)")
-        };
+		private static readonly List<(string Option, string Description)> _selectionDescriptions = new List<(string Option, string Description)>()
+		{
+			("f", "Full response"),
+			("p", "Partial Response (full headers, 50% of body), then wait indefinitely"),
+			("pc", "Partial Response (full headers, 50% of body), then close (TCP FIN)"),
+			("pa", "Partial Response (full headers, 50% of body), then abort (TCP RST)"),
+			("n", "No response, then wait indefinitely"),
+			("nc", "No response, then close (TCP FIN)"),
+			("na", "No response, then abort (TCP RST)")
+		};
 
-        private static readonly string[] _excludedRequestHeaders = new string[] {
+		private static readonly string[] _excludedRequestHeaders = new string[] {
             // Only applies to request between client and proxy
             "Proxy-Connection",
-        };
+			_responseSelectionHeader
+		};
 
-        // Headers which must be set on HttpContent instead of HttpRequestMessage
-        private static readonly string[] _contentRequestHeaders = new string[] {
-            "Content-Length",
-            "Content-Type",
-        };
+		// Headers which must be set on HttpContent instead of HttpRequestMessage
+		private static readonly string[] _contentRequestHeaders = new string[] {
+			"Content-Length",
+			"Content-Type",
+		};
 
-        private static readonly string _responseSelectionHeader = "x-ms-faultinjector-response-option";
+		private const string _responseSelectionHeader = "x-ms-faultinjector-response-option";
 
-        public static void Main(string[] args)
-        {
-            new WebHostBuilder()
-                .UseKestrel(options =>
-                {
-                    options.Listen(IPAddress.Any, 7777);
-                    options.Listen(IPAddress.Any, 7778, listenOptions =>
-                    {
-                        listenOptions.UseHttps("testCert.pfx", "testPassword");
-                    });
-                })
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .Configure(app => app.Run(async context =>
-                {
-                    try
-                    {
-                        var upstreamResponse = await SendUpstreamRequest(context.Request);
-                        
-                        // Attempt to remove the response selection header and use its value to handle the response selection.
-                        if (context.Request.Headers.Remove(_responseSelectionHeader, out var selection))
-                        {
-                            string optionDescription = _selectionDescriptions.FirstOrDefault(kvp => kvp.Key.Equals(selection)).Value;
-                            if (!String.IsNullOrEmpty(optionDescription) && await TryHandleResponseOption(selection, context, upstreamResponse))
-							{
-                                Console.WriteLine($"Using response option {_selectionDescriptions.First().Value} from header value.");
-                                return;
-                            }
-                        }
-
-                        // If we were passed an invalid response selection header, or none, continue prompting the user for input and attempt to handle the response.
-                        while (true)
-						{
-                            Console.WriteLine();
-
-                            Console.WriteLine("Select a response then press ENTER:");
-                            foreach (KeyValuePair<string, string> kvp in _selectionDescriptions)
-                            {
-                                Console.WriteLine($"{kvp.Key}: {kvp.Value}");
-                            }
-
-                            selection = Console.ReadLine();
-
-                            if (await TryHandleResponseOption(selection, context, upstreamResponse))
-                            {
-                                return;
-                            }
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        Console.WriteLine(e);
-                    }
-                }))
-                .Build()
-                .Run();
-        }
-
-        private static async Task<UpstreamResponse> SendUpstreamRequest(HttpRequest request)
-        {
-            var upstreamUriBuilder = new UriBuilder()
-            {
-                Scheme = request.Scheme,
-                Host = request.Host.Host,
-                Path = request.Path.Value,
-                Query = request.QueryString.Value,
-            };
-
-            if (request.Host.Port.HasValue)
-            {
-                upstreamUriBuilder.Port = request.Host.Port.Value;
-            }
-
-            var upstreamUri = upstreamUriBuilder.Uri;
-
-            Log("Upstream Request");
-            Log($"URL: {upstreamUri}");
-
-            using (var upstreamRequest = new HttpRequestMessage(new HttpMethod(request.Method), upstreamUri))
-            {
-                Log("Headers:");
-
-                if (request.ContentLength > 0)
-                {
-                    upstreamRequest.Content = new StreamContent(request.Body);
-
-                    foreach (var header in request.Headers.Where(h => _contentRequestHeaders.Contains(h.Key)))
-                    {
-                        Log($"  {header.Key}:{header.Value.First()}");
-                        upstreamRequest.Content.Headers.Add(header.Key, values: header.Value);
-                    }
-                }
-
-                foreach (var header in request.Headers.Where(h => !_excludedRequestHeaders.Contains(h.Key) && !_contentRequestHeaders.Contains(h.Key) && !h.Key.Equals(_responseSelectionHeader)))
-                {
-                    Log($"  {header.Key}:{header.Value.First()}");
-                    if (!upstreamRequest.Headers.TryAddWithoutValidation(header.Key, values: header.Value))
-                    {
-                        throw new InvalidOperationException($"Could not add header {header.Key} with value {header.Value}");
-                    }
-                }
-
-                Log("Sending request to upstream server...");
-                using (var upstreamResponseMessage = await _httpClient.SendAsync(upstreamRequest))
-                {
-                    Log("Upstream Response");
-                    var headers = new List<KeyValuePair<string, StringValues>>();
-
-                    Log($"StatusCode: {upstreamResponseMessage.StatusCode}");
-
-                    Log("Headers:");
-                    foreach (var header in upstreamResponseMessage.Headers)
-                    {
-                        Log($"  {header.Key}:{header.Value.First()}");
-
-                        // Must skip "Transfer-Encoding" header, since if it's set manually Kestrel requires you to implement
-                        // your own chunking.
-                        if (string.Equals(header.Key, "Transfer-Encoding", StringComparison.OrdinalIgnoreCase))
-                        {
-                            continue;
-                        }
-
-                        headers.Add(new KeyValuePair<string, StringValues>(header.Key, header.Value.ToArray()));
-                    }
-
-                    foreach (var header in upstreamResponseMessage.Content.Headers)
-                    {
-                        Log($"  {header.Key}:{header.Value.First()}");
-                        headers.Add(new KeyValuePair<string, StringValues>(header.Key, header.Value.ToArray()));
-                    }
-
-                    Log("Reading upstream response body...");
-
-                    var upstreamResponse = new UpstreamResponse()
-                    {
-                        StatusCode = (int)upstreamResponseMessage.StatusCode,
-                        Headers = headers.ToArray(),
-                        Content = await upstreamResponseMessage.Content.ReadAsByteArrayAsync()
-                    };
-
-                    Log($"ContentLength: {upstreamResponse.Content.Length}");
-
-                    return upstreamResponse;
-                }
-            }
-        }
-
-        private static async Task<bool> TryHandleResponseOption(string selection, HttpContext context, UpstreamResponse upstreamResponse)
+		public static void Main(string[] args)
 		{
-            switch (selection)
-            {
-                case "f":
-                    // Full response
-                    await SendDownstreamResponse(upstreamResponse, context.Response);
-                    return true;
-                case "p":
-                    // Partial Response (full headers, 50% of body), then wait indefinitely
-                    await SendDownstreamResponse(upstreamResponse, context.Response, upstreamResponse.Content.Length / 2);
-                    await Task.Delay(Timeout.InfiniteTimeSpan);
-                    return true;
-                case "pc":
-                    // Partial Response (full headers, 50% of body), then close (TCP FIN)
-                    await SendDownstreamResponse(upstreamResponse, context.Response, upstreamResponse.Content.Length / 2);
-                    Close(context);
-                    return true;
-                case "pa":
-                    // Partial Response (full headers, 50% of body), then abort (TCP RST)
-                    await SendDownstreamResponse(upstreamResponse, context.Response, upstreamResponse.Content.Length / 2);
-                    Abort(context);
-                    return true;
-                case "n":
-                    // No response, then wait indefinitely
-                    await Task.Delay(Timeout.InfiniteTimeSpan);
-                    return true;
-                case "nc":
-                    // No response, then close (TCP FIN)
-                    Close(context);
-                    return true;
-                case "na":
-                    // No response, then abort (TCP RST)
-                    Abort(context);
-                    return true;
-                default:
-                    Console.WriteLine($"Invalid selection: {selection}");
-                    return false;
-            }
-        }
+			new WebHostBuilder()
+				.UseKestrel(options =>
+				{
+					options.Listen(IPAddress.Any, 7777);
+					options.Listen(IPAddress.Any, 7778, listenOptions =>
+					{
+						listenOptions.UseHttps("testCert.pfx", "testPassword");
+					});
+				})
+				.UseContentRoot(Directory.GetCurrentDirectory())
+				.Configure(app => app.Run(async context =>
+				{
+					try
+					{
+						var upstreamResponse = await SendUpstreamRequest(context.Request);
 
-        private static async Task SendDownstreamResponse(UpstreamResponse upstreamResponse, HttpResponse response, int? contentBytes = null)
-        {
-            Log("Sending downstream response...");
+						// Attempt to remove the response selection header and use its value to handle the response selection.
+						if (context.Request.Headers.Remove(_responseSelectionHeader, out var selection))
+						{
+							string optionDescription = _selectionDescriptions.FirstOrDefault(kvp => kvp.Option.Equals(selection)).Description;
+							if (String.IsNullOrEmpty(optionDescription))
+							{
+								Console.WriteLine($"Invalid {_responseSelectionHeader} value {selection}.");
+							}
+							else if (await TryHandleResponseOption(selection, context, upstreamResponse))
+							{
+								Console.WriteLine($"Using response option {optionDescription} from header value.");
+								return;
+							}
+						}
 
-            response.StatusCode = upstreamResponse.StatusCode;
+						// If we were passed an invalid response selection header, or none, continue prompting the user for input and attempt to handle the response.
+						while (true)
+						{
+							Console.WriteLine();
 
-            Log($"StatusCode: {upstreamResponse.StatusCode}");
+							Console.WriteLine("Select a response then press ENTER:");
+							foreach (var selectionDescription in _selectionDescriptions)
+							{
+								Console.WriteLine($"{selectionDescription.Option}: {selectionDescription.Description}");
+							}
 
-            Log("Headers:");
-            foreach (var header in upstreamResponse.Headers)
-            {
-                Log($"  {header.Key}:{header.Value}");
-                response.Headers.Add(header.Key, header.Value);
-            }
+							selection = Console.ReadLine();
 
-            var count = contentBytes ?? upstreamResponse.Content.Length;
-            Log($"Writing response body of {count} bytes...");
-            await response.Body.WriteAsync(upstreamResponse.Content, 0, count);
-            Log($"Finished writing response body");
-        }
+							if (await TryHandleResponseOption(selection, context, upstreamResponse))
+							{
+								return;
+							}
+						}
+					}
+					catch (Exception e)
+					{
+						Console.WriteLine(e);
+					}
+				}))
+				.Build()
+				.Run();
+		}
 
-        // Close the TCP connection by sending FIN
-        private static void Close(HttpContext context)
-        {
-            context.Abort();
-        }
+		private static async Task<UpstreamResponse> SendUpstreamRequest(HttpRequest request)
+		{
+			var upstreamUriBuilder = new UriBuilder()
+			{
+				Scheme = request.Scheme,
+				Host = request.Host.Host,
+				Path = request.Path.Value,
+				Query = request.QueryString.Value,
+			};
 
-        // Abort the TCP connection by sending RST
-        private static void Abort(HttpContext context)
-        {
-            // SocketConnection registered "this" as the IConnectionIdFeature among other things.
-            var socketConnection = context.Features.Get<IConnectionIdFeature>();
-            var socket = (Socket)socketConnection.GetType().GetField("_socket", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(socketConnection);
-            socket.LingerState = new LingerOption(true, 0);
-            socket.Dispose();
-        }
+			if (request.Host.Port.HasValue)
+			{
+				upstreamUriBuilder.Port = request.Host.Port.Value;
+			}
 
-        private static void Log(object value)
-        {
-            Console.WriteLine($"[{DateTime.Now:hh:mm:ss.fff}] {value}");
-        }
+			var upstreamUri = upstreamUriBuilder.Uri;
 
-        private class UpstreamResponse
-        {
-            public int StatusCode { get; set; }
-            public KeyValuePair<string, StringValues>[] Headers { get; set; }
-            public byte[] Content { get; set; }
-        }
-    }
+			Log("Upstream Request");
+			Log($"URL: {upstreamUri}");
+
+			using (var upstreamRequest = new HttpRequestMessage(new HttpMethod(request.Method), upstreamUri))
+			{
+				Log("Headers:");
+
+				if (request.ContentLength > 0)
+				{
+					upstreamRequest.Content = new StreamContent(request.Body);
+
+					foreach (var header in request.Headers.Where(h => _contentRequestHeaders.Contains(h.Key)))
+					{
+						Log($"  {header.Key}:{header.Value.First()}");
+						upstreamRequest.Content.Headers.Add(header.Key, values: header.Value);
+					}
+				}
+
+				foreach (var header in request.Headers.Where(h => !_excludedRequestHeaders.Contains(h.Key) && !_contentRequestHeaders.Contains(h.Key)))
+				{
+					Log($"  {header.Key}:{header.Value.First()}");
+					if (!upstreamRequest.Headers.TryAddWithoutValidation(header.Key, values: header.Value))
+					{
+						throw new InvalidOperationException($"Could not add header {header.Key} with value {header.Value}");
+					}
+				}
+
+				Log("Sending request to upstream server...");
+				using (var upstreamResponseMessage = await _httpClient.SendAsync(upstreamRequest))
+				{
+					Log("Upstream Response");
+					var headers = new List<KeyValuePair<string, StringValues>>();
+
+					Log($"StatusCode: {upstreamResponseMessage.StatusCode}");
+
+					Log("Headers:");
+					foreach (var header in upstreamResponseMessage.Headers)
+					{
+						Log($"  {header.Key}:{header.Value.First()}");
+
+						// Must skip "Transfer-Encoding" header, since if it's set manually Kestrel requires you to implement
+						// your own chunking.
+						if (string.Equals(header.Key, "Transfer-Encoding", StringComparison.OrdinalIgnoreCase))
+						{
+							continue;
+						}
+
+						headers.Add(new KeyValuePair<string, StringValues>(header.Key, header.Value.ToArray()));
+					}
+
+					foreach (var header in upstreamResponseMessage.Content.Headers)
+					{
+						Log($"  {header.Key}:{header.Value.First()}");
+						headers.Add(new KeyValuePair<string, StringValues>(header.Key, header.Value.ToArray()));
+					}
+
+					Log("Reading upstream response body...");
+
+					var upstreamResponse = new UpstreamResponse()
+					{
+						StatusCode = (int)upstreamResponseMessage.StatusCode,
+						Headers = headers.ToArray(),
+						Content = await upstreamResponseMessage.Content.ReadAsByteArrayAsync()
+					};
+
+					Log($"ContentLength: {upstreamResponse.Content.Length}");
+
+					return upstreamResponse;
+				}
+			}
+		}
+
+		private static async Task<bool> TryHandleResponseOption(string selection, HttpContext context, UpstreamResponse upstreamResponse)
+		{
+			switch (selection)
+			{
+				case "f":
+					// Full response
+					await SendDownstreamResponse(upstreamResponse, context.Response);
+					return true;
+				case "p":
+					// Partial Response (full headers, 50% of body), then wait indefinitely
+					await SendDownstreamResponse(upstreamResponse, context.Response, upstreamResponse.Content.Length / 2);
+					await Task.Delay(Timeout.InfiniteTimeSpan);
+					return true;
+				case "pc":
+					// Partial Response (full headers, 50% of body), then close (TCP FIN)
+					await SendDownstreamResponse(upstreamResponse, context.Response, upstreamResponse.Content.Length / 2);
+					Close(context);
+					return true;
+				case "pa":
+					// Partial Response (full headers, 50% of body), then abort (TCP RST)
+					await SendDownstreamResponse(upstreamResponse, context.Response, upstreamResponse.Content.Length / 2);
+					Abort(context);
+					return true;
+				case "n":
+					// No response, then wait indefinitely
+					await Task.Delay(Timeout.InfiniteTimeSpan);
+					return true;
+				case "nc":
+					// No response, then close (TCP FIN)
+					Close(context);
+					return true;
+				case "na":
+					// No response, then abort (TCP RST)
+					Abort(context);
+					return true;
+				default:
+					Console.WriteLine($"Invalid selection: {selection}");
+					return false;
+			}
+		}
+
+		private static async Task SendDownstreamResponse(UpstreamResponse upstreamResponse, HttpResponse response, int? contentBytes = null)
+		{
+			Log("Sending downstream response...");
+
+			response.StatusCode = upstreamResponse.StatusCode;
+
+			Log($"StatusCode: {upstreamResponse.StatusCode}");
+
+			Log("Headers:");
+			foreach (var header in upstreamResponse.Headers)
+			{
+				Log($"  {header.Key}:{header.Value}");
+				response.Headers.Add(header.Key, header.Value);
+			}
+
+			var count = contentBytes ?? upstreamResponse.Content.Length;
+			Log($"Writing response body of {count} bytes...");
+			await response.Body.WriteAsync(upstreamResponse.Content, 0, count);
+			Log($"Finished writing response body");
+		}
+
+		// Close the TCP connection by sending FIN
+		private static void Close(HttpContext context)
+		{
+			context.Abort();
+		}
+
+		// Abort the TCP connection by sending RST
+		private static void Abort(HttpContext context)
+		{
+			// SocketConnection registered "this" as the IConnectionIdFeature among other things.
+			var socketConnection = context.Features.Get<IConnectionIdFeature>();
+			var socket = (Socket)socketConnection.GetType().GetField("_socket", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(socketConnection);
+			socket.LingerState = new LingerOption(true, 0);
+			socket.Dispose();
+		}
+
+		private static void Log(object value)
+		{
+			Console.WriteLine($"[{DateTime.Now:hh:mm:ss.fff}] {value}");
+		}
+
+		private class UpstreamResponse
+		{
+			public int StatusCode { get; set; }
+			public KeyValuePair<string, StringValues>[] Headers { get; set; }
+			public byte[] Content { get; set; }
+		}
+	}
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -17,273 +17,273 @@ using System.Threading.Tasks;
 
 namespace HttpFaultInjector
 {
-	public static class Program
-	{
-		private static readonly HttpClient _httpClient = new HttpClient();
+    public static class Program
+    {
+        private static readonly HttpClient _httpClient = new HttpClient();
 
-		private static readonly List<(string Option, string Description)> _selectionDescriptions = new List<(string Option, string Description)>()
-		{
-			("f", "Full response"),
-			("p", "Partial Response (full headers, 50% of body), then wait indefinitely"),
-			("pc", "Partial Response (full headers, 50% of body), then close (TCP FIN)"),
-			("pa", "Partial Response (full headers, 50% of body), then abort (TCP RST)"),
-			("n", "No response, then wait indefinitely"),
-			("nc", "No response, then close (TCP FIN)"),
-			("na", "No response, then abort (TCP RST)")
-		};
+        private static readonly List<(string Option, string Description)> _selectionDescriptions = new List<(string Option, string Description)>()
+        {
+            ("f", "Full response"),
+            ("p", "Partial Response (full headers, 50% of body), then wait indefinitely"),
+            ("pc", "Partial Response (full headers, 50% of body), then close (TCP FIN)"),
+            ("pa", "Partial Response (full headers, 50% of body), then abort (TCP RST)"),
+            ("n", "No response, then wait indefinitely"),
+            ("nc", "No response, then close (TCP FIN)"),
+            ("na", "No response, then abort (TCP RST)")
+        };
 
-		private static readonly string[] _excludedRequestHeaders = new string[] {
+        private static readonly string[] _excludedRequestHeaders = new string[] {
             // Only applies to request between client and proxy
             "Proxy-Connection",
-			_responseSelectionHeader
-		};
+            _responseSelectionHeader
+        };
 
-		// Headers which must be set on HttpContent instead of HttpRequestMessage
-		private static readonly string[] _contentRequestHeaders = new string[] {
-			"Content-Length",
-			"Content-Type",
-		};
+        // Headers which must be set on HttpContent instead of HttpRequestMessage
+        private static readonly string[] _contentRequestHeaders = new string[] {
+            "Content-Length",
+            "Content-Type",
+        };
 
-		private const string _responseSelectionHeader = "x-ms-faultinjector-response-option";
+        private const string _responseSelectionHeader = "x-ms-faultinjector-response-option";
 
-		public static void Main(string[] args)
-		{
-			new WebHostBuilder()
-				.UseKestrel(options =>
-				{
-					options.Listen(IPAddress.Any, 7777);
-					options.Listen(IPAddress.Any, 7778, listenOptions =>
-					{
-						listenOptions.UseHttps("testCert.pfx", "testPassword");
-					});
-				})
-				.UseContentRoot(Directory.GetCurrentDirectory())
-				.Configure(app => app.Run(async context =>
-				{
-					try
-					{
-						var upstreamResponse = await SendUpstreamRequest(context.Request);
+        public static void Main(string[] args)
+        {
+            new WebHostBuilder()
+                .UseKestrel(options =>
+                {
+                    options.Listen(IPAddress.Any, 7777);
+                    options.Listen(IPAddress.Any, 7778, listenOptions =>
+                    {
+                        listenOptions.UseHttps("testCert.pfx", "testPassword");
+                    });
+                })
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .Configure(app => app.Run(async context =>
+                {
+                    try
+                    {
+                        var upstreamResponse = await SendUpstreamRequest(context.Request);
 
-						// Attempt to remove the response selection header and use its value to handle the response selection.
-						if (context.Request.Headers.Remove(_responseSelectionHeader, out var selection))
-						{
-							string optionDescription = _selectionDescriptions.FirstOrDefault(kvp => kvp.Option.Equals(selection)).Description;
-							if (String.IsNullOrEmpty(optionDescription))
-							{
-								Console.WriteLine($"Invalid {_responseSelectionHeader} value {selection}.");
-							}
-							else if (await TryHandleResponseOption(selection, context, upstreamResponse))
-							{
-								Console.WriteLine($"Using response option {optionDescription} from header value.");
-								return;
-							}
-						}
+                        // Attempt to remove the response selection header and use its value to handle the response selection.
+                        if (context.Request.Headers.Remove(_responseSelectionHeader, out var selection))
+                        {
+                            string optionDescription = _selectionDescriptions.FirstOrDefault(kvp => kvp.Option.Equals(selection)).Description;
+                            if (String.IsNullOrEmpty(optionDescription))
+                            {
+                                Console.WriteLine($"Invalid {_responseSelectionHeader} value {selection}.");
+                            }
+                            else if (await TryHandleResponseOption(selection, context, upstreamResponse))
+                            {
+                                Console.WriteLine($"Using response option {optionDescription} from header value.");
+                                return;
+                            }
+                        }
 
-						// If we were passed an invalid response selection header, or none, continue prompting the user for input and attempt to handle the response.
-						while (true)
-						{
-							Console.WriteLine();
+                        // If we were passed an invalid response selection header, or none, continue prompting the user for input and attempt to handle the response.
+                        while (true)
+                        {
+                            Console.WriteLine();
 
-							Console.WriteLine("Select a response then press ENTER:");
-							foreach (var selectionDescription in _selectionDescriptions)
-							{
-								Console.WriteLine($"{selectionDescription.Option}: {selectionDescription.Description}");
-							}
+                            Console.WriteLine("Select a response then press ENTER:");
+                            foreach (var selectionDescription in _selectionDescriptions)
+                            {
+                                Console.WriteLine($"{selectionDescription.Option}: {selectionDescription.Description}");
+                            }
 
-							selection = Console.ReadLine();
+                            selection = Console.ReadLine();
 
-							if (await TryHandleResponseOption(selection, context, upstreamResponse))
-							{
-								return;
-							}
-						}
-					}
-					catch (Exception e)
-					{
-						Console.WriteLine(e);
-					}
-				}))
-				.Build()
-				.Run();
-		}
+                            if (await TryHandleResponseOption(selection, context, upstreamResponse))
+                            {
+                                return;
+                            }
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e);
+                    }
+                }))
+                .Build()
+                .Run();
+        }
 
-		private static async Task<UpstreamResponse> SendUpstreamRequest(HttpRequest request)
-		{
-			var upstreamUriBuilder = new UriBuilder()
-			{
-				Scheme = request.Scheme,
-				Host = request.Host.Host,
-				Path = request.Path.Value,
-				Query = request.QueryString.Value,
-			};
+        private static async Task<UpstreamResponse> SendUpstreamRequest(HttpRequest request)
+        {
+            var upstreamUriBuilder = new UriBuilder()
+            {
+                Scheme = request.Scheme,
+                Host = request.Host.Host,
+                Path = request.Path.Value,
+                Query = request.QueryString.Value,
+            };
 
-			if (request.Host.Port.HasValue)
-			{
-				upstreamUriBuilder.Port = request.Host.Port.Value;
-			}
+            if (request.Host.Port.HasValue)
+            {
+                upstreamUriBuilder.Port = request.Host.Port.Value;
+            }
 
-			var upstreamUri = upstreamUriBuilder.Uri;
+            var upstreamUri = upstreamUriBuilder.Uri;
 
-			Log("Upstream Request");
-			Log($"URL: {upstreamUri}");
+            Log("Upstream Request");
+            Log($"URL: {upstreamUri}");
 
-			using (var upstreamRequest = new HttpRequestMessage(new HttpMethod(request.Method), upstreamUri))
-			{
-				Log("Headers:");
+            using (var upstreamRequest = new HttpRequestMessage(new HttpMethod(request.Method), upstreamUri))
+            {
+                Log("Headers:");
 
-				if (request.ContentLength > 0)
-				{
-					upstreamRequest.Content = new StreamContent(request.Body);
+                if (request.ContentLength > 0)
+                {
+                    upstreamRequest.Content = new StreamContent(request.Body);
 
-					foreach (var header in request.Headers.Where(h => _contentRequestHeaders.Contains(h.Key)))
-					{
-						Log($"  {header.Key}:{header.Value.First()}");
-						upstreamRequest.Content.Headers.Add(header.Key, values: header.Value);
-					}
-				}
+                    foreach (var header in request.Headers.Where(h => _contentRequestHeaders.Contains(h.Key)))
+                    {
+                        Log($"  {header.Key}:{header.Value.First()}");
+                        upstreamRequest.Content.Headers.Add(header.Key, values: header.Value);
+                    }
+                }
 
-				foreach (var header in request.Headers.Where(h => !_excludedRequestHeaders.Contains(h.Key) && !_contentRequestHeaders.Contains(h.Key)))
-				{
-					Log($"  {header.Key}:{header.Value.First()}");
-					if (!upstreamRequest.Headers.TryAddWithoutValidation(header.Key, values: header.Value))
-					{
-						throw new InvalidOperationException($"Could not add header {header.Key} with value {header.Value}");
-					}
-				}
+                foreach (var header in request.Headers.Where(h => !_excludedRequestHeaders.Contains(h.Key) && !_contentRequestHeaders.Contains(h.Key)))
+                {
+                    Log($"  {header.Key}:{header.Value.First()}");
+                    if (!upstreamRequest.Headers.TryAddWithoutValidation(header.Key, values: header.Value))
+                    {
+                        throw new InvalidOperationException($"Could not add header {header.Key} with value {header.Value}");
+                    }
+                }
 
-				Log("Sending request to upstream server...");
-				using (var upstreamResponseMessage = await _httpClient.SendAsync(upstreamRequest))
-				{
-					Log("Upstream Response");
-					var headers = new List<KeyValuePair<string, StringValues>>();
+                Log("Sending request to upstream server...");
+                using (var upstreamResponseMessage = await _httpClient.SendAsync(upstreamRequest))
+                {
+                    Log("Upstream Response");
+                    var headers = new List<KeyValuePair<string, StringValues>>();
 
-					Log($"StatusCode: {upstreamResponseMessage.StatusCode}");
+                    Log($"StatusCode: {upstreamResponseMessage.StatusCode}");
 
-					Log("Headers:");
-					foreach (var header in upstreamResponseMessage.Headers)
-					{
-						Log($"  {header.Key}:{header.Value.First()}");
+                    Log("Headers:");
+                    foreach (var header in upstreamResponseMessage.Headers)
+                    {
+                        Log($"  {header.Key}:{header.Value.First()}");
 
-						// Must skip "Transfer-Encoding" header, since if it's set manually Kestrel requires you to implement
-						// your own chunking.
-						if (string.Equals(header.Key, "Transfer-Encoding", StringComparison.OrdinalIgnoreCase))
-						{
-							continue;
-						}
+                        // Must skip "Transfer-Encoding" header, since if it's set manually Kestrel requires you to implement
+                        // your own chunking.
+                        if (string.Equals(header.Key, "Transfer-Encoding", StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
 
-						headers.Add(new KeyValuePair<string, StringValues>(header.Key, header.Value.ToArray()));
-					}
+                        headers.Add(new KeyValuePair<string, StringValues>(header.Key, header.Value.ToArray()));
+                    }
 
-					foreach (var header in upstreamResponseMessage.Content.Headers)
-					{
-						Log($"  {header.Key}:{header.Value.First()}");
-						headers.Add(new KeyValuePair<string, StringValues>(header.Key, header.Value.ToArray()));
-					}
+                    foreach (var header in upstreamResponseMessage.Content.Headers)
+                    {
+                        Log($"  {header.Key}:{header.Value.First()}");
+                        headers.Add(new KeyValuePair<string, StringValues>(header.Key, header.Value.ToArray()));
+                    }
 
-					Log("Reading upstream response body...");
+                    Log("Reading upstream response body...");
 
-					var upstreamResponse = new UpstreamResponse()
-					{
-						StatusCode = (int)upstreamResponseMessage.StatusCode,
-						Headers = headers.ToArray(),
-						Content = await upstreamResponseMessage.Content.ReadAsByteArrayAsync()
-					};
+                    var upstreamResponse = new UpstreamResponse()
+                    {
+                        StatusCode = (int)upstreamResponseMessage.StatusCode,
+                        Headers = headers.ToArray(),
+                        Content = await upstreamResponseMessage.Content.ReadAsByteArrayAsync()
+                    };
 
-					Log($"ContentLength: {upstreamResponse.Content.Length}");
+                    Log($"ContentLength: {upstreamResponse.Content.Length}");
 
-					return upstreamResponse;
-				}
-			}
-		}
+                    return upstreamResponse;
+                }
+            }
+        }
 
-		private static async Task<bool> TryHandleResponseOption(string selection, HttpContext context, UpstreamResponse upstreamResponse)
-		{
-			switch (selection)
-			{
-				case "f":
-					// Full response
-					await SendDownstreamResponse(upstreamResponse, context.Response);
-					return true;
-				case "p":
-					// Partial Response (full headers, 50% of body), then wait indefinitely
-					await SendDownstreamResponse(upstreamResponse, context.Response, upstreamResponse.Content.Length / 2);
-					await Task.Delay(Timeout.InfiniteTimeSpan);
-					return true;
-				case "pc":
-					// Partial Response (full headers, 50% of body), then close (TCP FIN)
-					await SendDownstreamResponse(upstreamResponse, context.Response, upstreamResponse.Content.Length / 2);
-					Close(context);
-					return true;
-				case "pa":
-					// Partial Response (full headers, 50% of body), then abort (TCP RST)
-					await SendDownstreamResponse(upstreamResponse, context.Response, upstreamResponse.Content.Length / 2);
-					Abort(context);
-					return true;
-				case "n":
-					// No response, then wait indefinitely
-					await Task.Delay(Timeout.InfiniteTimeSpan);
-					return true;
-				case "nc":
-					// No response, then close (TCP FIN)
-					Close(context);
-					return true;
-				case "na":
-					// No response, then abort (TCP RST)
-					Abort(context);
-					return true;
-				default:
-					Console.WriteLine($"Invalid selection: {selection}");
-					return false;
-			}
-		}
+        private static async Task<bool> TryHandleResponseOption(string selection, HttpContext context, UpstreamResponse upstreamResponse)
+        {
+            switch (selection)
+            {
+                case "f":
+                    // Full response
+                    await SendDownstreamResponse(upstreamResponse, context.Response);
+                    return true;
+                case "p":
+                    // Partial Response (full headers, 50% of body), then wait indefinitely
+                    await SendDownstreamResponse(upstreamResponse, context.Response, upstreamResponse.Content.Length / 2);
+                    await Task.Delay(Timeout.InfiniteTimeSpan);
+                    return true;
+                case "pc":
+                    // Partial Response (full headers, 50% of body), then close (TCP FIN)
+                    await SendDownstreamResponse(upstreamResponse, context.Response, upstreamResponse.Content.Length / 2);
+                    Close(context);
+                    return true;
+                case "pa":
+                    // Partial Response (full headers, 50% of body), then abort (TCP RST)
+                    await SendDownstreamResponse(upstreamResponse, context.Response, upstreamResponse.Content.Length / 2);
+                    Abort(context);
+                    return true;
+                case "n":
+                    // No response, then wait indefinitely
+                    await Task.Delay(Timeout.InfiniteTimeSpan);
+                    return true;
+                case "nc":
+                    // No response, then close (TCP FIN)
+                    Close(context);
+                    return true;
+                case "na":
+                    // No response, then abort (TCP RST)
+                    Abort(context);
+                    return true;
+                default:
+                    Console.WriteLine($"Invalid selection: {selection}");
+                    return false;
+            }
+        }
 
-		private static async Task SendDownstreamResponse(UpstreamResponse upstreamResponse, HttpResponse response, int? contentBytes = null)
-		{
-			Log("Sending downstream response...");
+        private static async Task SendDownstreamResponse(UpstreamResponse upstreamResponse, HttpResponse response, int? contentBytes = null)
+        {
+            Log("Sending downstream response...");
 
-			response.StatusCode = upstreamResponse.StatusCode;
+            response.StatusCode = upstreamResponse.StatusCode;
 
-			Log($"StatusCode: {upstreamResponse.StatusCode}");
+            Log($"StatusCode: {upstreamResponse.StatusCode}");
 
-			Log("Headers:");
-			foreach (var header in upstreamResponse.Headers)
-			{
-				Log($"  {header.Key}:{header.Value}");
-				response.Headers.Add(header.Key, header.Value);
-			}
+            Log("Headers:");
+            foreach (var header in upstreamResponse.Headers)
+            {
+                Log($"  {header.Key}:{header.Value}");
+                response.Headers.Add(header.Key, header.Value);
+            }
 
-			var count = contentBytes ?? upstreamResponse.Content.Length;
-			Log($"Writing response body of {count} bytes...");
-			await response.Body.WriteAsync(upstreamResponse.Content, 0, count);
-			Log($"Finished writing response body");
-		}
+            var count = contentBytes ?? upstreamResponse.Content.Length;
+            Log($"Writing response body of {count} bytes...");
+            await response.Body.WriteAsync(upstreamResponse.Content, 0, count);
+            Log($"Finished writing response body");
+        }
 
-		// Close the TCP connection by sending FIN
-		private static void Close(HttpContext context)
-		{
-			context.Abort();
-		}
+        // Close the TCP connection by sending FIN
+        private static void Close(HttpContext context)
+        {
+            context.Abort();
+        }
 
-		// Abort the TCP connection by sending RST
-		private static void Abort(HttpContext context)
-		{
-			// SocketConnection registered "this" as the IConnectionIdFeature among other things.
-			var socketConnection = context.Features.Get<IConnectionIdFeature>();
-			var socket = (Socket)socketConnection.GetType().GetField("_socket", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(socketConnection);
-			socket.LingerState = new LingerOption(true, 0);
-			socket.Dispose();
-		}
+        // Abort the TCP connection by sending RST
+        private static void Abort(HttpContext context)
+        {
+            // SocketConnection registered "this" as the IConnectionIdFeature among other things.
+            var socketConnection = context.Features.Get<IConnectionIdFeature>();
+            var socket = (Socket)socketConnection.GetType().GetField("_socket", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(socketConnection);
+            socket.LingerState = new LingerOption(true, 0);
+            socket.Dispose();
+        }
 
-		private static void Log(object value)
-		{
-			Console.WriteLine($"[{DateTime.Now:hh:mm:ss.fff}] {value}");
-		}
+        private static void Log(object value)
+        {
+            Console.WriteLine($"[{DateTime.Now:hh:mm:ss.fff}] {value}");
+        }
 
-		private class UpstreamResponse
-		{
-			public int StatusCode { get; set; }
-			public KeyValuePair<string, StringValues>[] Headers { get; set; }
-			public byte[] Content { get; set; }
-		}
-	}
+        private class UpstreamResponse
+        {
+            public int StatusCode { get; set; }
+            public KeyValuePair<string, StringValues>[] Headers { get; set; }
+            public byte[] Content { get; set; }
+        }
+    }
 }


### PR DESCRIPTION
This PR adds support for a custom header, `x-ms-faultinjector-response-option`, to allow for requests to the fault injector server to automatically select their response option.